### PR TITLE
Corrected file path for angular-json-editor.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then include the directive and json-editor in your html (you can also use the mi
     
 ```html
 <script src="bower_components/json-editor/dist/jsoneditor.js"></script>
-<script src="bower_components/angular-json-editor/angular-json-editor.js"></script>
+<script src="bower_components/angular-json-editor/dist/angular-json-editor.js"></script>
 ```
 
 Usage


### PR DESCRIPTION
I noticed the readme says "angular-json-editor/angular-json-editor.js", however, the file is under angular-json-editor/dist/ . I've changed the path to reflect this. 
